### PR TITLE
added boxcar averaging functionality

### DIFF
--- a/omen-fan.py
+++ b/omen-fan.py
@@ -53,6 +53,7 @@ def startup_check():
         doc["service"]["SPEED_CURVE"] = [20, 40, 60, 70, 85, 100]
         doc["service"]["IDLE_SPEED"] = 0
         doc["service"]["POLL_INTERVAL"] = 1
+        doc["service"]["BOXCAR_LENGTH"] = 5
 
         doc.add("script", tomlkit.table())
         doc["script"]["BYPASS_DEVICE_CHECK"] = 0

--- a/omen-fand.py
+++ b/omen-fand.py
@@ -27,6 +27,7 @@ with open(CONFIG_FILE, "r") as file:
     SPEED_CURVE = doc["service"]["SPEED_CURVE"].unwrap()
     IDLE_SPEED = doc["service"]["IDLE_SPEED"].unwrap()
     POLL_INTERVAL = doc["service"]["POLL_INTERVAL"].unwrap()
+    BOXCAR_LENGTH = doc["service"]["BOXCAR_LENGTH"].unwrap()
 
 # Precalculate slopes to reduce compute time.
 slope = []
@@ -91,10 +92,18 @@ with open(IPC_FILE, "w", encoding="utf-8") as ipc:
     ipc.write(str(os.getpid()))
 
 speed_old = -1
+temp_old = [get_temp()] * BOXCAR_LENGTH
 is_root()
 
 while True:
-    temp = get_temp()
+    temp = 0
+    for i in range(0, BOXCAR_LENGTH - 1):
+        temp_old[i] = temp_old[i + 1]
+        temp = temp + temp_old[i]
+
+    temp_old[BOXCAR_LENGTH - 1] = get_temp()
+    temp = temp + temp_old[BOXCAR_LENGTH - 1]
+    temp = temp / BOXCAR_LENGTH
 
     if temp <= TEMP_CURVE[0]:
         speed = IDLE_SPEED


### PR DESCRIPTION
When running the original code, I often encountered one fluke temperature value sent the fans spinning like crazy, only to come back down really quickly. The time behaviour of the fan speed adaptation was much faster than the thermal mass of the system could absorb heat, so it appears instantaneous adaptation was too volatile.

Therefore I implemented a simple form of low-pass filtering where we simply average the last n temperature measurements, known as boxcar averaging.
In the settings you can indicate how many temperature measurements are averaged. Together with the interval parameter, you can now express the temporal behaviour of the fan speed adaptation. The reaction speed to a step in temperature is now (interval * Nboxcar) so with the default values, the system now ramps up or down in 5 seconds. I've played with values as large as 30 seconds to really smooth out the fan speed modulation and it worked fine. The value of 5 I consider to be an absolutely safe value together with the default temp curve.