### PR TITLE
fix daemon call

### DIFF
--- a/omen-fan.py
+++ b/omen-fan.py
@@ -253,7 +253,7 @@ def service_cli(arg):
                 print(f"  omen-fan service is already running with PID:{ipc.read()}")
         else:
             bios_control(False)
-            subprocess.Popen("omen-fand")
+            subprocess.Popen("./omen-fand.py")
             print("  omen-fan service has been started")
 
     elif arg in ["stop", "0"]:


### PR DESCRIPTION
omen-fand cannot be found without file extension or path indicator 
```
sudo ./omen-fan.py e 1
  WARNING: BIOS Fan Control Disabled
Traceback (most recent call last):
  File "/home/slightlywind/Repositories/omen-fan/./omen-fan.py", line 340, in <module>
    cli()
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/slightlywind/Repositories/omen-fan/./omen-fan.py", line 256, in service_cli
    subprocess.Popen("omen-fand")
  File "/usr/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.12/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'omen-fand'
```