### PR TITLE
Add OMEN 15 (84DB) support with EC 0xEC fan boost fallback

### DIFF
--- a/docs/probes.md
+++ b/docs/probes.md
@@ -19,7 +19,9 @@ Registers with ? are writable but something effects the system and sometimes doe
 0x2F    Fan 2 Speed %       Range 0 - 0x64 (100)
 0xB3    Fan 2 Speed         Range 0 - 0x16 
 
-0xEC?   Fan Boost           00 (Boost OFF), 0x0C (Boost ON)
+0xEC*   Fan Boost           00 (Boost OFF), 0x0C (Boost ON on some models)
+                            On board 84DB (OMEN 15-dc0xxx, Linux): write 1 = max,
+                            write 0 = auto — see hp-omen-fan-linux test results
 0xF4*   Fan State           00 (Enable), 02 (Disable)
 ```
 

--- a/omen-fan.py
+++ b/omen-fan.py
@@ -28,7 +28,9 @@ BOOST_OFFSET = 236  # 0xEC
 
 FAN1_SPEED_MAX = 55
 FAN2_SPEED_MAX = 57
-DEVICE_LIST = ["OMEN by HP Laptop 16"]
+DEVICE_LIST = ["OMEN by HP Laptop 16", "OMEN by HP Laptop 15"]
+# Legacy OMEN 15 (2018-2019): WMI pwm1_enable max fails; EC 0xEC works with value 1.
+EC_FAN_BOOST_BOARDS = {"84DA", "84DB", "84DC"}
 
 
 def is_root(state=0):
@@ -113,6 +115,29 @@ def update_fan(speed1, speed2):
         ec.write(bytes([speed2]))
 
 
+def board_uses_ec_fan_boost():
+    try:
+        with open("/sys/class/dmi/id/board_name", "r", encoding="utf-8") as f:
+            return f.read().strip() in EC_FAN_BOOST_BOARDS
+    except OSError:
+        return False
+
+
+def ec_fan_boost(enabled):
+    with open(ECIO_FILE, "r+b") as ec:
+        ec.seek(BOOST_OFFSET)
+        ec.write(bytes([1 if enabled else 0]))
+
+
+def set_fan_boost(enabled):
+    """Enable or disable fan boost via sysfs or EC fallback."""
+    if board_uses_ec_fan_boost():
+        ec_fan_boost(enabled)
+        return
+    with open(BOOST_FILE, "r+", encoding="utf-8") as file:
+        file.write("2" if not enabled else "0")
+
+
 def bios_control(enabled):
     if enabled is False:
         print("  WARNING: BIOS Fan Control Disabled")
@@ -182,12 +207,7 @@ def bios_control_cli(arg):
 def boost_cli(arg):
     is_root()
     load_ec_module()
-    if arg is False:
-        with open(BOOST_FILE, "r+", encoding="utf-8") as file:
-            file.write("2")
-    elif arg is True:
-        with open(BOOST_FILE, "r+", encoding="utf-8") as file:
-            file.write("0")
+    set_fan_boost(arg)
 
 
 @cli.command(
@@ -302,10 +322,18 @@ def info_cli():
     with open(FAN2_SPEED_FILE, "r", encoding="utf-8") as fan2:
         print(f"  Fan 2 : {fan2.read().strip()} RPM")
 
-    with open(BOOST_FILE, "r", encoding="utf-8") as boost:
-        if boost.read().strip() == "0":
-            print("\n  Fan Boost : Enabled")
-            print("  Fan speeds are now maxed. BIOS and User controls are ignored")
+    boost_enabled = False
+    if board_uses_ec_fan_boost() and is_root(1):
+        load_ec_module()
+        with open(ECIO_FILE, "rb") as ec:
+            ec.seek(BOOST_OFFSET)
+            boost_enabled = int.from_bytes(ec.read(1), "big") == 1
+    else:
+        with open(BOOST_FILE, "r", encoding="utf-8") as boost:
+            boost_enabled = boost.read().strip() == "0"
+    if boost_enabled:
+        print("\n  Fan Boost : Enabled")
+        print("  Fan speeds are now maxed. BIOS and User controls are ignored")
 
 
 @cli.command(


### PR DESCRIPTION
## Summary

Tested fan control on **OMEN by HP Laptop 15-dc0xxx** (board `84DB`, BIOS F.19, kernel `7.0.0-27-generic`).

- Fan RPM readback via `hp-wmi` hwmon works
- `pwm1_enable=0` (max mode via sysfs) returns **EINVAL** on stock kernel
- EC offset **`0xEC`** with value **`1`** forces max fans (~4600/5300 RPM vs ~3600/3400 auto)

This PR:
- Adds `OMEN by HP Laptop 15` to `DEVICE_LIST`
- Routes `omen-fan boost` through EC `0xEC` on boards `84DA`/`84DB`/`84DC`
- Updates `docs/probes.md` with 84DB-tested boost values (note: value `1` on Linux, not `0x0C`)

## Test plan

- [x] `omen-fan info` on board 84DB
- [x] `omen-fan boost true` → RPM rises to ~4600/5300
- [x] `omen-fan boost false` → restores auto
- [ ] Confirm on 84DA / 84DC (assumed same generation)

## References

- Research repo: https://github.com/murilopontes/hp-omen-fan-linux
- Evidence: `data/evidence-84DB.txt`, `docs/TEST-RESULTS.md`
- Kernel draft patch: EC fallback for upstream `hp-wmi`